### PR TITLE
Fix PowerShell variable syntax in DatabaseUtils.psm1

### DIFF
--- a/SQLDatabaseCreation/DatabaseUtils.psm1
+++ b/SQLDatabaseCreation/DatabaseUtils.psm1
@@ -440,48 +440,48 @@ function Test-DbaSufficientDiskSpace {
         $requiredDataSpaceWithMarginMB = [Math]::Ceiling($requiredDataSpaceMB * $safetyMultiplier)
         $requiredLogSpaceWithMarginMB = [Math]::Ceiling($requiredLogSpaceMB * $safetyMultiplier)
         
-        Write-Verbose "Required space: Data drive = ${requiredDataSpaceWithMarginMB}MB (${NumberOfDataFiles} files × ${dataSizeMB}MB + ${SafetyMarginPercent}% margin)"
-        Write-Verbose "Required space: Log drive = ${requiredLogSpaceWithMarginMB}MB (${logSizeMB}MB + ${SafetyMarginPercent}% margin)"
+        Write-Verbose "Required space: Data drive = $(requiredDataSpaceWithMarginMB)MB ($(NumberOfDataFiles) files × $(dataSizeMB)MB + $(SafetyMarginPercent)% margin)"
+        Write-Verbose "Required space: Log drive = $(requiredLogSpaceWithMarginMB)MB ($(logSizeMB)MB + $(SafetyMarginPercent)% margin)"
         
-        $dataDriveName = "${DataDrive}:"
+        $dataDriveName = "$(DataDrive):"
         $dataDiskInfo = $diskInfo | Where-Object { $_.Name -eq $dataDriveName }
         
         if (-not $dataDiskInfo) {
-            Write-Error "Data drive ${dataDriveName} not found on SQL Server host"
+            Write-Error "Data drive $(dataDriveName) not found on SQL Server host"
             return $false
         }
         
         $dataAvailableMB = [Math]::Floor($dataDiskInfo.Free / 1MB)
-        Write-Verbose "Data drive ${dataDriveName} has ${dataAvailableMB}MB free"
+        Write-Verbose "Data drive $(dataDriveName) has $(dataAvailableMB)MB free"
         
         if ($dataAvailableMB -lt $requiredDataSpaceWithMarginMB) {
-            Write-Error "Insufficient space on data drive ${dataDriveName}: ${dataAvailableMB}MB available, ${requiredDataSpaceWithMarginMB}MB required (including ${SafetyMarginPercent}% safety margin)"
+            Write-Error "Insufficient space on data drive $(dataDriveName): $(dataAvailableMB)MB available, $(requiredDataSpaceWithMarginMB)MB required (including $(SafetyMarginPercent)% safety margin)"
             return $false
         }
         
         if ($LogDrive -ne $DataDrive) {
-            $logDriveName = "${LogDrive}:"
+            $logDriveName = "$(LogDrive):"
             $logDiskInfo = $diskInfo | Where-Object { $_.Name -eq $logDriveName }
             
             if (-not $logDiskInfo) {
-                Write-Error "Log drive ${logDriveName} not found on SQL Server host"
+                Write-Error "Log drive $(logDriveName) not found on SQL Server host"
                 return $false
             }
             
             $logAvailableMB = [Math]::Floor($logDiskInfo.Free / 1MB)
-            Write-Verbose "Log drive ${logDriveName} has ${logAvailableMB}MB free"
+            Write-Verbose "Log drive $(logDriveName) has $(logAvailableMB)MB free"
             
             if ($logAvailableMB -lt $requiredLogSpaceWithMarginMB) {
-                Write-Error "Insufficient space on log drive ${logDriveName}: ${logAvailableMB}MB available, ${requiredLogSpaceWithMarginMB}MB required (including ${SafetyMarginPercent}% safety margin)"
+                Write-Error "Insufficient space on log drive $(logDriveName): $(logAvailableMB)MB available, $(requiredLogSpaceWithMarginMB)MB required (including $(SafetyMarginPercent)% safety margin)"
                 return $false
             }
         }
         else {
             $combinedRequiredMB = $requiredDataSpaceWithMarginMB + $requiredLogSpaceWithMarginMB
-            Write-Verbose "Combined requirement for drive ${dataDriveName}: ${combinedRequiredMB}MB"
+            Write-Verbose "Combined requirement for drive $(dataDriveName): $(combinedRequiredMB)MB"
             
             if ($dataAvailableMB -lt $combinedRequiredMB) {
-                Write-Error "Insufficient space on drive ${dataDriveName}: ${dataAvailableMB}MB available, ${combinedRequiredMB}MB required for both data and log (including ${SafetyMarginPercent}% safety margin)"
+                Write-Error "Insufficient space on drive $(dataDriveName): $(dataAvailableMB)MB available, $(combinedRequiredMB)MB required for both data and log (including $(SafetyMarginPercent)% safety margin)"
                 return $false
             }
         }


### PR DESCRIPTION
# Fix PowerShell variable syntax in DatabaseUtils.psm1

## Summary

This PR fixes PowerShell variable syntax in the `Test-DbaSufficientDiskSpace` function by replacing all 21 instances of `${varname}` with `$(varname)` in string interpolation contexts.

**Context**: This is a follow-up to PR #1. The original variable syntax fix was pushed to the PR branch after PR #1 was already merged, so it never made it into master. The user reported that `Test-DbaSufficientDiskSpace` "does not exist" when trying to import the module, likely due to PowerShell parse errors caused by the incorrect variable syntax in master.

**Changes**: All changes are within the `Test-DbaSufficientDiskSpace` function in `Write-Verbose`, `Write-Error`, and variable assignment statements.

## Review & Testing Checklist for Human

**⚠️ Critical - Must test on Windows with PowerShell:**

- [ ] **Module Import**: Verify `Import-Module ./SQLDatabaseCreation/DatabaseUtils.psd1` works without parse errors
- [ ] **Function Accessibility**: Confirm `Get-Command Test-DbaSufficientDiskSpace` returns the function (should resolve the "function does not exist" issue)
- [ ] **Function Execution**: Test the function with sample parameters to ensure it actually runs and produces expected output
- [ ] **Integration Test**: Run the full database creation workflow (`.\Invoke-DatabaseCreation.ps1`) to ensure disk space validation works end-to-end

### Notes

- **Testing Limitation**: This fix was implemented on Linux and could not be tested with actual PowerShell - Windows testing is essential
- **Syntax Assumption**: Both `${var}` and `$(var)` are valid PowerShell syntax, but this change assumes `$(var)` is the preferred format for this codebase
- **Session Reference**: Link to Devin run: https://app.devin.ai/sessions/6fc028dc743143ce966b7d00232f9ab7 | Requested by @karim-attaleb