### PR TITLE
CRITICAL: Revert incorrect PowerShell variable syntax from PR #2

### DIFF
--- a/SQLDatabaseCreation/DatabaseUtils.psm1
+++ b/SQLDatabaseCreation/DatabaseUtils.psm1
@@ -440,48 +440,48 @@ function Test-DbaSufficientDiskSpace {
         $requiredDataSpaceWithMarginMB = [Math]::Ceiling($requiredDataSpaceMB * $safetyMultiplier)
         $requiredLogSpaceWithMarginMB = [Math]::Ceiling($requiredLogSpaceMB * $safetyMultiplier)
         
-        Write-Verbose "Required space: Data drive = $(requiredDataSpaceWithMarginMB)MB ($(NumberOfDataFiles) files × $(dataSizeMB)MB + $(SafetyMarginPercent)% margin)"
-        Write-Verbose "Required space: Log drive = $(requiredLogSpaceWithMarginMB)MB ($(logSizeMB)MB + $(SafetyMarginPercent)% margin)"
+        Write-Verbose "Required space: Data drive = ${requiredDataSpaceWithMarginMB}MB (${NumberOfDataFiles} files × ${dataSizeMB}MB + ${SafetyMarginPercent}% margin)"
+        Write-Verbose "Required space: Log drive = ${requiredLogSpaceWithMarginMB}MB (${logSizeMB}MB + ${SafetyMarginPercent}% margin)"
         
-        $dataDriveName = "$(DataDrive):"
+        $dataDriveName = "${DataDrive}:"
         $dataDiskInfo = $diskInfo | Where-Object { $_.Name -eq $dataDriveName }
         
         if (-not $dataDiskInfo) {
-            Write-Error "Data drive $(dataDriveName) not found on SQL Server host"
+            Write-Error "Data drive ${dataDriveName} not found on SQL Server host"
             return $false
         }
         
         $dataAvailableMB = [Math]::Floor($dataDiskInfo.Free / 1MB)
-        Write-Verbose "Data drive $(dataDriveName) has $(dataAvailableMB)MB free"
+        Write-Verbose "Data drive ${dataDriveName} has ${dataAvailableMB}MB free"
         
         if ($dataAvailableMB -lt $requiredDataSpaceWithMarginMB) {
-            Write-Error "Insufficient space on data drive $(dataDriveName): $(dataAvailableMB)MB available, $(requiredDataSpaceWithMarginMB)MB required (including $(SafetyMarginPercent)% safety margin)"
+            Write-Error "Insufficient space on data drive ${dataDriveName}: ${dataAvailableMB}MB available, ${requiredDataSpaceWithMarginMB}MB required (including ${SafetyMarginPercent}% safety margin)"
             return $false
         }
         
         if ($LogDrive -ne $DataDrive) {
-            $logDriveName = "$(LogDrive):"
+            $logDriveName = "${LogDrive}:"
             $logDiskInfo = $diskInfo | Where-Object { $_.Name -eq $logDriveName }
             
             if (-not $logDiskInfo) {
-                Write-Error "Log drive $(logDriveName) not found on SQL Server host"
+                Write-Error "Log drive ${logDriveName} not found on SQL Server host"
                 return $false
             }
             
             $logAvailableMB = [Math]::Floor($logDiskInfo.Free / 1MB)
-            Write-Verbose "Log drive $(logDriveName) has $(logAvailableMB)MB free"
+            Write-Verbose "Log drive ${logDriveName} has ${logAvailableMB}MB free"
             
             if ($logAvailableMB -lt $requiredLogSpaceWithMarginMB) {
-                Write-Error "Insufficient space on log drive $(logDriveName): $(logAvailableMB)MB available, $(requiredLogSpaceWithMarginMB)MB required (including $(SafetyMarginPercent)% safety margin)"
+                Write-Error "Insufficient space on log drive ${logDriveName}: ${logAvailableMB}MB available, ${requiredLogSpaceWithMarginMB}MB required (including ${SafetyMarginPercent}% safety margin)"
                 return $false
             }
         }
         else {
             $combinedRequiredMB = $requiredDataSpaceWithMarginMB + $requiredLogSpaceWithMarginMB
-            Write-Verbose "Combined requirement for drive $(dataDriveName): $(combinedRequiredMB)MB"
+            Write-Verbose "Combined requirement for drive ${dataDriveName}: ${combinedRequiredMB}MB"
             
             if ($dataAvailableMB -lt $combinedRequiredMB) {
-                Write-Error "Insufficient space on drive $(dataDriveName): $(dataAvailableMB)MB available, $(combinedRequiredMB)MB required for both data and log (including $(SafetyMarginPercent)% safety margin)"
+                Write-Error "Insufficient space on drive ${dataDriveName}: ${dataAvailableMB}MB available, ${combinedRequiredMB}MB required for both data and log (including ${SafetyMarginPercent}% safety margin)"
                 return $false
             }
         }


### PR DESCRIPTION
# CRITICAL: Revert incorrect PowerShell variable syntax from PR #2

## Summary

This PR reverts the incorrect PowerShell variable syntax changes introduced in PR #2. The previous PR changed all instances of `${varname}` to `$(varname)` in the `Test-DbaSufficientDiskSpace` function, but this was **incorrect PowerShell syntax**.

**Root cause**: PowerShell uses `${varname}` for variable expansion in strings, while `$(expression)` is for subexpression evaluation. The incorrect syntax in master is causing module import failures with errors like:
```
The term 'requiredDataSpaceWithMarginMB' is not recognized as the name of a cmdlet, function, script file, or operable program
```

**Changes**: Reverts all 21 instances from `$(varname)` back to `${varname}` in string interpolation contexts within the `Test-DbaSufficientDiskSpace` function.

## Review & Testing Checklist for Human

**⚠️ CRITICAL - Master is currently broken and needs immediate fix**

- [ ] **Verify PowerShell module imports without errors**: `Import-Module ./SQLDatabaseCreation/DatabaseUtils.psd1 -Force`
- [ ] **Test function accessibility**: `Get-Command Test-DbaSufficientDiskSpace` should return the function
- [ ] **Run full database creation workflow**: Execute `.\Invoke-DatabaseCreation.ps1 -ConfigPath .\DatabaseConfig.psd1` to ensure no regressions
- [ ] **Validate syntax against Microsoft docs**: Confirm `${var}` syntax matches [PowerShell specification](https://learn.microsoft.com/en-us/powershell/scripting/lang-spec/chapter-05?view=powershell-7.5)

### Notes

- **Session**: https://app.devin.ai/sessions/6fc028dc743143ce966b7d00232f9ab7
- **Requested by**: @karim-attaleb
- **Urgency**: HIGH - This fixes a breaking change that made the module non-functional
- **Testing limitation**: Changes cannot be tested on Linux, requires Windows PowerShell validation
- The only remaining `$()` instances are legitimate exception handling: `$($_.Exception.Message)`