### PR TITLE
Add Windows Event Log configuration to default config

### DIFF
--- a/SQLDatabaseCreation/Invoke-DatabaseCreation.ps1
+++ b/SQLDatabaseCreation/Invoke-DatabaseCreation.ps1
@@ -124,6 +124,8 @@ try {
             }
             Logins = @()
             Users = @()
+            EnableEventLog = $true
+            EventLogSource = "SQLDatabaseScripts"
         }
         Write-Verbose "Using default configuration"
     }


### PR DESCRIPTION
# Add Windows Event Log configuration to default config

## Summary
Added Windows Event Log configuration (`EnableEventLog` and `EventLogSource`) to the default configuration used when `ConfigPath` parameter is not provided. This ensures Windows Event Log integration is enabled by default when using the new parameter-based approach introduced in PR #9.

**Changes:**
- Set `EnableEventLog = $true` in default config
- Set `EventLogSource = "SQLDatabaseScripts"` in default config

## Review & Testing Checklist for Human

- [ ] **Verify Windows Event Log integration works**: Run the script with parameter-based approach (without ConfigPath) and confirm events are written to Windows Application Event Log under source "SQLDatabaseScripts"
- [ ] **Confirm default behavior is appropriate**: Verify that enabling Event Log by default is the desired behavior for your environment

### Test Plan
1. Run the script using parameter-based approach:
   ```powershell
   ./Invoke-DatabaseCreation.ps1 -SqlInstance "SERVER\INSTANCE" -Database_Name "TestDB" -ExpectedDatabaseSize "50GB"
   ```
2. Check Windows Event Viewer → Application Log for events from source "SQLDatabaseScripts"
3. Verify Success, Error, and Warning events are logged appropriately

### Notes
- This addresses the missing Windows Event Log configuration that was noticed after PR #9 was merged
- The same settings already exist in the ConfigPath-based approach; this just adds them to the default config
- No logic changes, only configuration defaults

---
**Session**: https://app.devin.ai/sessions/00b458f6d1ca43fbb982b757e5992e24  
**Requested by**: karim_attaleb01@yahoo.fr (@karim-attaleb)