### PR TITLE
Replace Invoke-DbaQuery with Add-DbaDbFile, rename scripts, add params, and early exit

### DIFF
--- a/SQLDatabaseCreation/Invoke-DatabaseCreation.ps1
+++ b/SQLDatabaseCreation/Invoke-DatabaseCreation.ps1
@@ -365,19 +365,16 @@ try {
                     $logicalFileName = "${Database_Name}_Data$i"
                     $physicalFileName = "$dataDirectory\${Database_Name}_Data$i.ndf"
                     
-                    $addFileSql = @"
-ALTER DATABASE [$Database_Name]
-ADD FILE (
-    NAME = N'$logicalFileName',
-    FILENAME = N'$physicalFileName',
-    SIZE = ${perFileSizeMB}MB,
-    FILEGROWTH = ${dataGrowthMB}MB
-) TO FILEGROUP [PRIMARY]
-"@
-                    
                     if ($PSCmdlet.ShouldProcess("$Database_Name", "Add data file $i to PRIMARY filegroup")) {
                         try {
-                            Invoke-DbaQuery -SqlInstance $SqlInstance -Database $Database_Name -Query $addFileSql -ErrorAction Stop
+                            Add-DbaDbFile -SqlInstance $SqlInstance `
+                                -Database $Database_Name `
+                                -FileGroup "PRIMARY" `
+                                -FileName $logicalFileName `
+                                -Path $physicalFileName `
+                                -Size $perFileSizeMB `
+                                -Growth $dataGrowthMB `
+                                -ErrorAction Stop
                             Write-Log -Message "Added data file $i ($logicalFileName) to PRIMARY filegroup" -Level Info -LogFile $logFile -EnableEventLog $false
                         }
                         catch {


### PR DESCRIPTION
## Summary
Replaced the raw SQL `ALTER DATABASE ADD FILE` command executed via `Invoke-DbaQuery` with the native dbatools `Add-DbaDbFile` cmdlet for adding additional data files to the PRIMARY filegroup. This provides better integration with the dbatools ecosystem and more consistent error handling.

**Before**: Raw T-SQL executed via `Invoke-DbaQuery`
**After**: Native `Add-DbaDbFile` cmdlet with typed parameters

### Updates since last revision
**Restructured script for early exit behavior**:
- Database existence check now happens immediately after SQL connection (exits early if database exists)
- Disk space validation now happens before directory initialization (exits early if insufficient space)
- Directory initialization only occurs after all early exit checks pass
- Updated documentation to reflect new order of operations

New execution order:
1. Connect to SQL Server
2. Check if database exists → **EXIT EARLY** if exists
3. Derive drive paths and calculate file sizes
4. Validate disk space → **EXIT EARLY** if insufficient
5. Initialize directories
6. Create database and configure

### Previous updates
**Removed login/user management code** (preparing for redesign):
- Removed all login/user creation code from main script
- Removed `Add-SqlServerLogin` and `Add-DatabaseUser` functions from module
- Removed `Logins` and `Users` sections from config file

**Added new mandatory parameters**:
- `Pillar` - Environment pillar (DEV, UAC, PROD)
- `Datagroup` - Data group identifier

**Renamed script files** to follow `pod_sql_*` naming convention:
- `Invoke-DatabaseCreation.ps1` → `pod_sql_invoke-databasecreation.ps1`
- `DatabaseUtils.psm1` → `pod_sql_databaseutils.psm1`
- `DatabaseConfig.psd1` → `pod_sql_databaseconfig.psd1`

## Review & Testing Checklist for Human

- [ ] **BREAKING CHANGE - New mandatory parameters**: Any existing scripts calling this will need to add `-Pillar` and `-Datagroup` parameters
- [ ] **BREAKING CHANGE - Login/user removal**: If you were using the `Logins` or `Users` config sections, this functionality is now removed
- [ ] **Verify early exit behavior**: Test that script exits immediately when database already exists (no directory creation should occur)
- [ ] **Verify early exit on disk space**: Test that script exits before directory creation when disk space is insufficient
- [ ] **Verify file renames don't break external references**: Check if any documentation, CI pipelines, or external scripts reference the old filenames

### Test Plan
1. **Test early exit (database exists)**:
   - Create a test database manually
   - Run script with same database name - should exit immediately after connection
   - Verify no directories were created

2. **Test normal flow**:
   - Run: `.\SQLDatabaseCreation\pod_sql_invoke-databasecreation.ps1 -SqlInstance "SERVER\INSTANCE" -Database_Name "TestDB" -ExpectedDatabaseSize "50GB" -Pillar "DEV" -Datagroup "DG01"`
   - Verify 5 data files were created (50GB / 10GB threshold)
   - Query `sys.database_files` to confirm file placement and sizes

### Notes
- **Local testing completed**: Successfully tested early exit scenarios on SQL Server 2025 container (localhost:1434)
- Test confirmed database existence check exits before any directory operations
- Existing Pester test failures (13) are pre-existing and unrelated to this change (42 tests passed)

---
**Session**: https://app.devin.ai/sessions/f60d9c5910404e038fd1420057e235f6
**Requested by**: karim_attaleb01@yahoo.fr (@karim-attaleb)