### PR TITLE
Fix db_owner role to only apply to DEV_RW login

### DIFF
--- a/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
+++ b/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
@@ -59,8 +59,8 @@
     8. Set database owner to 'sa'
     9. Enable Query Store (SQL Server 2016+)
     10. Create logins and database users based on Pillar:
-        - DEV: 1005_GS_{Datagroup}0_DEV_RW, 1005_GS_{Datagroup}0_FNC_RW, 
-               1005_GS_{Datagroup}0_PRS_RO, 1005_GS_{Datagroup}0_PRS_RW (with db_owner role)
+        - DEV: 1005_GS_{Datagroup}0_DEV_RW (with db_owner role), 1005_GS_{Datagroup}0_FNC_RW, 
+               1005_GS_{Datagroup}0_PRS_RO, 1005_GS_{Datagroup}0_PRS_RW
         - UAC/PROD: 0005_GS_{Datagroup}0_FNC_RW, 0005_GS_{Datagroup}0_PRS_RO, 
                     0005_GS_{Datagroup}0_PRS_RW
 
@@ -398,8 +398,8 @@ try {
                             Write-Log -Message "User '$loginName' already exists in database, skipping creation" -Level Info -LogFile $logFile -EnableEventLog $false
                         }
                         
-                        # If Pillar is DEV, add user to db_owner role
-                        if ($Pillar -eq 'DEV') {
+                        # If Pillar is DEV and this is the DEV_RW login, add user to db_owner role
+                        if ($Pillar -eq 'DEV' -and $loginName -like '*_DEV_RW') {
                             Add-DbaDbRoleMember -SqlInstance $SqlInstance -Database $Database_Name -Role 'db_owner' -User $loginName -ErrorAction Stop
                             Write-Log -Message "Added user '$loginName' to db_owner role" -Level Info -LogFile $logFile -EnableEventLog $false
                         }
@@ -424,7 +424,7 @@ try {
             Write-Log -Message "  - Query Store: $(if ($server.VersionMajor -ge 13) { 'Enabled' } else { 'Not Available' })" -Level Info -LogFile $logFile -EnableEventLog $false
             Write-Log -Message "  - Pillar: $Pillar, Datagroup: $Datagroup" -Level Info -LogFile $logFile -EnableEventLog $false
             Write-Log -Message "  - Logins/Users created: $($loginNames -join ', ')" -Level Info -LogFile $logFile -EnableEventLog $false
-            Write-Log -Message "  - Database role: $(if ($Pillar -eq 'DEV') { 'db_owner' } else { 'None (default)' })" -Level Info -LogFile $logFile -EnableEventLog $false
+            Write-Log -Message "  - Database role: $(if ($Pillar -eq 'DEV') { 'db_owner (DEV_RW only)' } else { 'None (default)' })" -Level Info -LogFile $logFile -EnableEventLog $false
         }
         catch {
             Write-Log -Message "Failed to create database: $($_.Exception.Message)" -Level Error -LogFile $logFile -EnableEventLog $enableEventLog -EventLogSource $eventLogSource


### PR DESCRIPTION
## Summary

Fixes the db_owner role assignment to only apply to the `_DEV_RW` login instead of all DEV pillar logins.

**Before:** All 4 DEV logins (`DEV_RW`, `FNC_RW`, `PRS_RO`, `PRS_RW`) received `db_owner` role
**After:** Only `1005_GS_{Datagroup}0_DEV_RW` receives `db_owner` role

The condition was changed from:
```powershell
if ($Pillar -eq 'DEV')
```
to:
```powershell
if ($Pillar -eq 'DEV' -and $loginName -like '*_DEV_RW')
```

## Review & Testing Checklist for Human

- [ ] **Verify pattern matching**: Confirm `*_DEV_RW` correctly matches login names like `1005_GS_MSS0_DEV_RW` (the wildcard should match the prefix)
- [ ] **Test on domain-joined SQL Server**: Run with `Pillar "DEV"` and verify only the `_DEV_RW` user has `db_owner` role, while `_FNC_RW`, `_PRS_RO`, `_PRS_RW` do not

### Test Plan
1. Create a database with `-Pillar "DEV" -Datagroup "MSS"`
2. Query role membership: `SELECT dp.name, r.name as role FROM sys.database_role_members drm JOIN sys.database_principals dp ON drm.member_principal_id = dp.principal_id JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id WHERE r.name = 'db_owner'`
3. Verify only `1005_GS_MSS0_DEV_RW` appears in results

### Notes
- This is a permission reduction (more restrictive than before)
- Documentation and log messages updated to reflect the change

---
**Session**: https://app.devin.ai/sessions/f60d9c5910404e038fd1420057e235f6
**Requested by**: karim_attaleb01@yahoo.fr (@karim-attaleb)