### PR TITLE
Add optional Collation parameter and fix New-DbaLogin call

### DIFF
--- a/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
+++ b/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
@@ -25,6 +25,9 @@
 .PARAMETER Datagroup
     The data group identifier.
 
+.PARAMETER Collation
+    The database collation. Default is 'Latin1_General_CI_AS'.
+
 .PARAMETER ConfigPath
     Optional path to a PowerShell data file (.psd1) containing additional configuration.
     If provided, FileSizes and Logging settings will be loaded from the config file.
@@ -85,6 +88,9 @@ param(
     
     [Parameter(Mandatory = $true, HelpMessage = "Data group identifier")]
     [string]$Datagroup,
+    
+    [Parameter(Mandatory = $false, HelpMessage = "Database collation")]
+    [string]$Collation = 'Latin1_General_CI_AS',
     
     [Parameter(Mandatory = $false, HelpMessage = "Optional path to configuration file for additional settings")]
     [ValidateScript({

--- a/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
+++ b/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
@@ -261,6 +261,7 @@ try {
         Write-Log -Message "  - Log file size: $($config.FileSizes.LogSize)" -Level Info -LogFile $logFile -EnableEventLog $false
         Write-Log -Message "  - Data file growth: $($config.FileSizes.DataGrowth)" -Level Info -LogFile $logFile -EnableEventLog $false
         Write-Log -Message "  - Log file growth: $($config.FileSizes.LogGrowth)" -Level Info -LogFile $logFile -EnableEventLog $false
+        Write-Log -Message "  - Collation: $Collation" -Level Info -LogFile $logFile -EnableEventLog $false
 
         $newDbParams = @{
             SqlInstance = $SqlInstance
@@ -271,6 +272,7 @@ try {
             LogSize = (Convert-SizeToInt $config.FileSizes.LogSize)
             PrimaryFileGrowth = (Convert-SizeToInt $config.FileSizes.DataGrowth)
             LogGrowth = (Convert-SizeToInt $config.FileSizes.LogGrowth)
+            Collation = $Collation
         }
 
         try {
@@ -427,6 +429,7 @@ try {
             Write-Log -Message "  - Data file location: $dataDirectory" -Level Info -LogFile $logFile -EnableEventLog $false
             Write-Log -Message "  - Log file location: $logDirectory" -Level Info -LogFile $logFile -EnableEventLog $false
             Write-Log -Message "  - Owner: sa" -Level Info -LogFile $logFile -EnableEventLog $false
+            Write-Log -Message "  - Collation: $Collation" -Level Info -LogFile $logFile -EnableEventLog $false
             Write-Log -Message "  - Query Store: $(if ($server.VersionMajor -ge 13) { 'Enabled' } else { 'Not Available' })" -Level Info -LogFile $logFile -EnableEventLog $false
             Write-Log -Message "  - Pillar: $Pillar, Datagroup: $Datagroup" -Level Info -LogFile $logFile -EnableEventLog $false
             Write-Log -Message "  - Logins/Users created: $($loginNames -join ', ')" -Level Info -LogFile $logFile -EnableEventLog $false


### PR DESCRIPTION
## Summary

Adds an optional `Collation` parameter to the main database creation script with a default value of `Latin1_General_CI_AS`. The collation is now applied when creating the database.

**Changes:**
- Added `Collation` parameter (non-mandatory, string type)
- Default value: `Latin1_General_CI_AS`
- Added parameter documentation
- Collation is passed to `New-DbaDatabase` command
- Collation is logged in configuration and summary messages

## Updates since last revision

- **Removed `LoginType` parameter from `New-DbaLogin`**: The `New-DbaLogin` cmdlet does not have a `LoginType` parameter. Removed `-LoginType WindowsGroup` from the login creation call.

## Review & Testing Checklist for Human

- [ ] **Verify login creation works**: With `LoginType` removed, confirm that logins are created correctly. `New-DbaLogin` should auto-detect the login type based on the login name format.
- [ ] **Verify default collation value**: User requested `latin1_Gneral_CI_AS` (appears to be a typo) - I used `Latin1_General_CI_AS`. Confirm this is the correct collation name for your environment.
- [ ] **Test with custom collation**: Create a database with a non-default collation (e.g., `SQL_Latin1_General_CP1_CI_AS`) and verify it's applied correctly.

### Test Plan
1. Run script with `-WhatIf` to verify parameters are accepted
2. Create a test database and verify collation with: `SELECT name, collation_name FROM sys.databases WHERE name = 'YourDatabaseName'`
3. Verify logins are created correctly: `SELECT name, type_desc FROM sys.server_principals WHERE name LIKE '%_GS_%'`

### Notes
- No validation on collation string - invalid collation names will cause runtime errors from SQL Server
- Login type will be auto-detected by dbatools based on the login name

---
**Session**: https://app.devin.ai/sessions/f60d9c5910404e038fd1420057e235f6
**Requested by**: karim_attaleb01@yahoo.fr (@karim-attaleb)