### PR TITLE
Remove LoginType parameter from New-DbaLogin

### DIFF
--- a/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
+++ b/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
@@ -387,8 +387,8 @@ try {
                         # Check if login already exists
                         $existingLogin = Get-DbaLogin -SqlInstance $SqlInstance -Login $loginName -ErrorAction SilentlyContinue
                         if (-not $existingLogin) {
-                            # Create Windows login (assuming these are Windows/AD groups)
-                            New-DbaLogin -SqlInstance $SqlInstance -Login $loginName -LoginType WindowsGroup -ErrorAction Stop
+                            # Create login
+                            New-DbaLogin -SqlInstance $SqlInstance -Login $loginName -ErrorAction Stop
                             Write-Log -Message "Created login: $loginName" -Level Info -LogFile $logFile -EnableEventLog $false
                         }
                         else {


### PR DESCRIPTION
## Summary

Removes the `-LoginType WindowsGroup` parameter from the `New-DbaLogin` call, as this parameter does not exist in the dbatools cmdlet. The login type will now be auto-detected by dbatools based on the login name format.

## Review & Testing Checklist for Human

- [ ] **Verify login creation works correctly**: Test that logins like `1005_GS_MSS0_DEV_RW` are created with the correct type. Without explicit `LoginType`, dbatools will auto-detect based on the login name.
- [ ] **Test on domain-joined SQL Server**: Run the full database creation script and verify logins are created as expected: `SELECT name, type_desc FROM sys.server_principals WHERE name LIKE '%_GS_%'`

### Test Plan
1. Run the database creation script with `-Pillar "DEV" -Datagroup "TST"`
2. Query `sys.server_principals` to verify logins were created
3. Confirm the login type is appropriate for your environment

### Notes
- This is a fix for an invalid parameter - the previous code would have failed when attempting to create logins
- dbatools should auto-detect Windows logins based on the naming pattern

---
**Session**: https://app.devin.ai/sessions/f60d9c5910404e038fd1420057e235f6
**Requested by**: karim_attaleb01@yahoo.fr (@karim-attaleb)