### PR TITLE
Add domain prefix, create all files in one go, remove config file

### DIFF
--- a/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
+++ b/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
@@ -62,10 +62,12 @@
     8. Set database owner to 'sa'
     9. Enable Query Store (SQL Server 2016+)
     10. Create logins and database users based on Pillar:
-        - DEV: 1005_GS_{Datagroup}0_DEV_RW (with db_owner role), 1005_GS_{Datagroup}0_FNC_RW, 
-               1005_GS_{Datagroup}0_PRS_RO, 1005_GS_{Datagroup}0_PRS_RW
-        - UAC/PROD: 0005_GS_{Datagroup}0_FNC_RW, 0005_GS_{Datagroup}0_PRS_RO, 
-                    0005_GS_{Datagroup}0_PRS_RW
+        - DEV: TD1001\1005_GS_{Datagroup}0_DEV_RW (with db_owner role), TD1001\1005_GS_{Datagroup}0_FNC_RW, 
+               TD1001\1005_GS_{Datagroup}0_PRS_RO, TD1001\1005_GS_{Datagroup}0_PRS_RW
+        - UAC: TD1001\0005_GS_{Datagroup}0_FNC_RW, TD1001\0005_GS_{Datagroup}0_PRS_RO, 
+               TD1001\0005_GS_{Datagroup}0_PRS_RW
+        - PROD: GLOW001\0005_GS_{Datagroup}0_FNC_RW, GLOW001\0005_GS_{Datagroup}0_PRS_RO, 
+                GLOW001\0005_GS_{Datagroup}0_PRS_RW
 
 .LINK
     https://github.com/karim-attaleb/sqlserver-databasescripts
@@ -360,21 +362,30 @@ try {
             # Create logins and users based on Pillar
             Write-Log -Message "Creating logins and users based on Pillar '$Pillar' and Datagroup '$Datagroup'..." -Level Info -LogFile $logFile -EnableEventLog $false
             
+            # Determine domain prefix based on Pillar
+            if ($Pillar -eq 'PROD') {
+                $domainPrefix = 'GLOW001\'
+            }
+            else {
+                # DEV or UAC
+                $domainPrefix = 'TD1001\'
+            }
+            
             # Determine login names based on Pillar
             if ($Pillar -eq 'DEV') {
                 $loginNames = @(
-                    "1005_GS_${Datagroup}0_DEV_RW",
-                    "1005_GS_${Datagroup}0_FNC_RW",
-                    "1005_GS_${Datagroup}0_PRS_RO",
-                    "1005_GS_${Datagroup}0_PRS_RW"
+                    "${domainPrefix}1005_GS_${Datagroup}0_DEV_RW",
+                    "${domainPrefix}1005_GS_${Datagroup}0_FNC_RW",
+                    "${domainPrefix}1005_GS_${Datagroup}0_PRS_RO",
+                    "${domainPrefix}1005_GS_${Datagroup}0_PRS_RW"
                 )
             }
             else {
                 # UAC or PROD
                 $loginNames = @(
-                    "0005_GS_${Datagroup}0_FNC_RW",
-                    "0005_GS_${Datagroup}0_PRS_RO",
-                    "0005_GS_${Datagroup}0_PRS_RW"
+                    "${domainPrefix}0005_GS_${Datagroup}0_FNC_RW",
+                    "${domainPrefix}0005_GS_${Datagroup}0_PRS_RO",
+                    "${domainPrefix}0005_GS_${Datagroup}0_PRS_RW"
                 )
             }
             


### PR DESCRIPTION
## Summary

This PR includes three main changes:

1. **Windows domain prefixes for login names**: The domain prefix is determined by the Pillar parameter:
   - **DEV/UAC**: `TD1001\` prefix (e.g., `TD1001\1005_GS_MSS0_DEV_RW`)
   - **PROD**: `GLOW001\` prefix (e.g., `GLOW001\0005_GS_MSS0_FNC_RW`)

2. **Database creation with all data files in one go**: Instead of creating the database with one primary file and then adding additional files via `Add-DbaDbFile` loop, the script now uses `SecondaryFileCount`, `SecondaryFilesize`, and `SecondaryFileGrowth` parameters in `New-DbaDatabase` to create all data files in a single call.

3. **Removed configuration file dependency**: The `ConfigPath` parameter has been removed. The script now uses hardcoded default values directly:
   - DataGrowth: 100MB
   - LogSize: 100MB
   - LogGrowth: 100MB
   - FileSizeThreshold: 10GB

## Updates since last revision

- **Removed ConfigPath parameter**: Configuration file support has been removed per user request. All configuration values are now hardcoded defaults. Tested parameter parsing and database creation with default values on SQL Server 2025 container.

## Review & Testing Checklist for Human

- [ ] **Verify default values are acceptable**: DataGrowth=100MB, LogSize=100MB, LogGrowth=100MB, FileSizeThreshold=10GB are now hardcoded with no override option.
- [ ] **Verify domain names are correct**: Confirm `TD1001` is the correct domain for DEV/UAC and `GLOW001` is correct for PROD. These are hardcoded.
- [ ] **Verify pillar name**: User mentioned "DEV or ACC" but code uses "UAC". Confirm the correct pillar name.
- [ ] **Test multi-file database creation**: Run with different `ExpectedDatabaseSize` values and verify the correct number of data files are created in PRIMARY filegroup.
- [ ] **Test db_owner role assignment**: Verify the `-Confirm:$false` fix resolves the hanging issue when adding DEV_RW user to db_owner role.

### Test Plan
1. Run with `-ExpectedDatabaseSize "50GB"` and verify 5 data files are created in one go
2. Run with `-Pillar "DEV" -Datagroup "TST"` and verify login names start with `TD1001\1005_GS_TST0_`
3. Run with `-Pillar "PROD" -Datagroup "TST"` and verify login names start with `GLOW001\0005_GS_TST0_`
4. Verify DEV_RW user gets db_owner role without script hanging
5. Confirm the script works without any `-ConfigPath` parameter

### Notes
- Multi-file creation and default config values tested on SQL Server 2025 container (localhost:1434)
- Domain login changes cannot be fully tested on Linux SQL Server container as it requires domain-joined environment with actual AD groups
- The `pod_sql_databaseconfig.psd1` file still exists in the repo but is no longer used by the main script

---
**Session**: https://app.devin.ai/sessions/f60d9c5910404e038fd1420057e235f6
**Requested by**: karim_attaleb01@yahoo.fr (@karim-attaleb)