### PR TITLE
Load config values from psd1 file instead of hardcoded defaults

### DIFF
--- a/SQLDatabaseCreation/pod_sql_databaseconfig.psd1
+++ b/SQLDatabaseCreation/pod_sql_databaseconfig.psd1
@@ -1,36 +1,21 @@
 @{
-    # SQL Server Configuration
-    SqlInstance = "YourSQLServerInstance"
-
-    # Database Configuration
-    Database = @{
-        Name = "DB_MSS0_DEMO"
-        DataDrive = "G"
-        LogDrive = "L"
-        
-        # Expected total database size used to automatically calculate
-        # the optimal number of data files based on FileSizeThreshold.
-        # If size > threshold, multiple files will be created.
-        # Otherwise, a single file will be used.
-        # Examples: "50GB", "500MB", "1TB"
-        ExpectedDatabaseSize = "5GB"
-    }
-
     # File Configuration
+    # These values control database file sizes and growth settings
     FileSizes = @{
-        DataSize = "200MB"
-        DataGrowth = "100MB"
-        LogSize = "100MB"
-        LogGrowth = "100MB"
+        # Growth increment for data files
+        DataGrowth = "512MB"
+        
+        # Initial size for log file
+        LogSize = "1024MB"
+        
+        # Growth increment for log file
+        LogGrowth = "512MB"
         
         # Maximum desired size for each data file.
         # Used to calculate optimal number of files when ExpectedDatabaseSize is specified.
-        FileSizeThreshold = "10GB"
+        FileSizeThreshold = "500MB"
     }
 
-    # Logging
-    LogFile = "DatabaseCreation.log"
-    
     # Windows Event Log integration (requires administrative privileges)
     # Set to $true to write important events to Windows Application Event Log
     EnableEventLog = $true

--- a/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
+++ b/SQLDatabaseCreation/pod_sql_invoke-databasecreation.ps1
@@ -124,14 +124,29 @@ catch {
     exit 1
 }
 
-# Default configuration values
-$dataGrowth = "512MB"
-$logSize = "1024MB"
-$logGrowth = "512MB"
-$fileSizeThreshold = "500MB"
+# Load configuration from psd1 file (must be in same location as script)
+$configPath = Join-Path $PSScriptRoot "pod_sql_databaseconfig.psd1"
+if (-not (Test-Path $configPath)) {
+    Write-Error "Configuration file not found at: $configPath"
+    exit 1
+}
+
+try {
+    $config = Import-PowerShellDataFile -Path $configPath -ErrorAction Stop
+}
+catch {
+    Write-Error "Failed to load configuration file: $($_.Exception.Message)"
+    exit 1
+}
+
+# Extract configuration values
+$dataGrowth = $config.FileSizes.DataGrowth
+$logSize = $config.FileSizes.LogSize
+$logGrowth = $config.FileSizes.LogGrowth
+$fileSizeThreshold = $config.FileSizes.FileSizeThreshold
 $logFile = "$PSScriptRoot\DatabaseCreation.log"
-$enableEventLog = $true
-$eventLogSource = "SQLDatabaseScripts"
+$enableEventLog = $config.EnableEventLog
+$eventLogSource = $config.EventLogSource
 
 try {
     


### PR DESCRIPTION
## Summary

Changes the database creation script to load configuration values from `pod_sql_databaseconfig.psd1` instead of using hardcoded defaults. The config file must be in the same location as the main script. The script exits early with a clear error if the config file is not found.

**Config file cleanup:** Removed settings that are now passed as script parameters (SqlInstance, Database name, DataDrive, LogDrive, ExpectedDatabaseSize, LogFile). The config file now only contains:
- `FileSizes`: DataGrowth, LogSize, LogGrowth, FileSizeThreshold
- `EnableEventLog`, `EventLogSource`

## Review & Testing Checklist for Human

- [ ] **Verify config file will be present in deployment** - Script now requires `pod_sql_databaseconfig.psd1` to exist in the same directory. This is a breaking change if the file is missing.
- [ ] **Verify config values are appropriate** - Current defaults: DataGrowth=512MB, LogSize=1024MB, LogGrowth=512MB, FileSizeThreshold=500MB. Adjust if needed for your environment.
- [ ] **Test missing config file scenario** - Remove/rename the psd1 file and verify script exits with clear error message

### Test Plan
1. Run script with config file present - verify it loads values correctly
2. Remove config file temporarily - verify script exits with "Configuration file not found" error
3. Corrupt config file (invalid syntax) - verify script exits with "Failed to load configuration file" error

### Notes
- Could not fully test on Linux container (Windows logins require domain-joined environment)
- The config values match what was previously hardcoded in the script

---
**Session**: https://app.devin.ai/sessions/f60d9c5910404e038fd1420057e235f6
**Requested by**: karim_attaleb01@yahoo.fr (@karim-attaleb)